### PR TITLE
Fixed flaky group_elements_by_length test

### DIFF
--- a/src/test/java/snippets/SnippetsTests.java
+++ b/src/test/java/snippets/SnippetsTests.java
@@ -229,7 +229,7 @@ public class SnippetsTests {
     public void group_elements_by_length() throws Exception {
         Map<Integer, List<String>> groups = Snippets.groupBy(new String[]{"one", "two", "three"}, String::length);
         assertThat(groups)
-                .containsExactly(
+                .containsOnly(
                         new SimpleEntry<>(3, Arrays.asList("one", "two")),
                         new SimpleEntry<>(5, Collections.singletonList("three"))
                 );


### PR DESCRIPTION
Fixed the group_elements_by_length test, which made the incorrect assumption that groupBy preserves the order in which it checks the first element of each group. This commit modifies the test to make element checking order agnostic by using the `containsOnly` method of `assertThat` instead of `containsExactly`.